### PR TITLE
Add test ci workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - README.md
+      - 'examples/*'
+jobs:
+  test:
+    if: '!github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: Run unit tests
+        run: go test


### PR DESCRIPTION
Run `go test` on PR:s that

- Targets the main branch
- Are not draft PRs
- Only update go files

Using a cache for getting go packages is built-in to the `setup-go` action, no need to run `go get`.